### PR TITLE
Rework serialization of parameter sweep configuration

### DIFF
--- a/src/main/java/fiji/plugin/trackmate/helper/model/AbstractSweepModelBase.java
+++ b/src/main/java/fiji/plugin/trackmate/helper/model/AbstractSweepModelBase.java
@@ -8,12 +8,12 @@
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-3.0.html>.
@@ -38,7 +38,7 @@ public abstract class AbstractSweepModelBase implements SciJavaPlugin
 		public void modelChanged();
 	}
 
-	private transient Listeners.List< ModelListener > modelListeners;
+	private final transient Listeners.List< ModelListener > modelListeners = new Listeners.SynchronizedList<>();
 
 	protected final String name;
 
@@ -68,16 +68,6 @@ public abstract class AbstractSweepModelBase implements SciJavaPlugin
 
 	public final Listeners.List< ModelListener > listeners()
 	{
-		if ( modelListeners == null )
-		{
-			/*
-			 * Work around the listeners field being null after deserialization.
-			 * We also need to register again the sub-models.
-			 */
-			this.modelListeners = new Listeners.SynchronizedList<>();
-			for ( final AbstractParamSweepModel< ? > model : models.values() )
-				model.listeners().add( () -> notifyListeners() );
-		}
 		return modelListeners;
 	}
 

--- a/src/main/java/fiji/plugin/trackmate/helper/model/ParameterSweepModelIO.java
+++ b/src/main/java/fiji/plugin/trackmate/helper/model/ParameterSweepModelIO.java
@@ -8,12 +8,12 @@
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-3.0.html>.
@@ -34,6 +34,8 @@ import java.util.stream.Collectors;
 
 import javax.swing.JOptionPane;
 
+import com.google.gson.ExclusionStrategy;
+import com.google.gson.FieldAttributes;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
@@ -49,8 +51,9 @@ import com.google.gson.JsonSerializer;
 import fiji.plugin.trackmate.detection.SpotDetectorFactoryBase;
 import fiji.plugin.trackmate.gui.Icons;
 import fiji.plugin.trackmate.helper.model.detector.DetectorSweepModel;
+import fiji.plugin.trackmate.helper.model.parameter.AbstractArrayParamSweepModel.RangeType;
 import fiji.plugin.trackmate.helper.model.parameter.AbstractParamSweepModel;
-import fiji.plugin.trackmate.helper.model.parameter.ArrayParamSweepModel.RangeType;
+import fiji.plugin.trackmate.helper.model.parameter.CondaEnvParamSweepModel;
 import fiji.plugin.trackmate.helper.model.parameter.EnumParamSweepModel;
 import fiji.plugin.trackmate.helper.model.tracker.TrackerSweepModel;
 import fiji.plugin.trackmate.providers.DetectorProvider;
@@ -67,7 +70,7 @@ public class ParameterSweepModelIO
 	/**
 	 * Makes a file object that will save settings in the folder containing the
 	 * specified ground-truth folder.
-	 * 
+	 *
 	 * @param groundTruthPath
 	 *            the ground-truth folder.
 	 * @return a {@link File}.
@@ -155,6 +158,7 @@ public class ParameterSweepModelIO
 	private static Gson getGson()
 	{
 		final GsonBuilder builder = new GsonBuilder()
+				.addDeserializationExclusionStrategy( new CustomExclusionStrategy() )
 				.registerTypeAdapter( EnumParamSweepModel.class, new EnumParamSweepModelAdapter<>() )
 				.registerTypeAdapter( SpotDetectorFactoryBase.class, new SpotDetectorFactoryBaseAdapter() )
 				.registerTypeAdapter( SpotTrackerFactory.class, new SpotTrackerFactoryAdapter() )
@@ -175,6 +179,21 @@ public class ParameterSweepModelIO
 		final ParameterSweepModel model = getGson().fromJson( str, ParameterSweepModel.class );
 		model.registerListeners();
 		return model;
+	}
+
+	private static class CustomExclusionStrategy implements ExclusionStrategy
+	{
+		@Override
+		public boolean shouldSkipField( final FieldAttributes f )
+		{
+			return f.getDeclaringClass() == CondaEnvParamSweepModel.class && f.getName().equals( "allValues" );
+		}
+
+		@Override
+		public boolean shouldSkipClass( final Class< ? > clazz )
+		{
+			return false;
+		}
 	}
 
 	private static class AbstractParamSweepModelAdapter implements JsonSerializer< AbstractParamSweepModel< ? > >, JsonDeserializer< AbstractParamSweepModel< ? > >

--- a/src/main/java/fiji/plugin/trackmate/helper/model/detector/CellposeOpt.java
+++ b/src/main/java/fiji/plugin/trackmate/helper/model/detector/CellposeOpt.java
@@ -8,12 +8,12 @@
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-3.0.html>.
@@ -31,8 +31,10 @@ import fiji.plugin.trackmate.cellpose.CellposeSettings.PretrainedModelCellpose;
 import fiji.plugin.trackmate.detection.DetectorKeys;
 import fiji.plugin.trackmate.detection.SpotDetectorFactoryBase;
 import fiji.plugin.trackmate.detection.ThresholdDetectorFactory;
+import fiji.plugin.trackmate.helper.model.parameter.AbstractArrayParamSweepModel.ArrayRangeType;
 import fiji.plugin.trackmate.helper.model.parameter.AbstractParamSweepModel;
 import fiji.plugin.trackmate.helper.model.parameter.BooleanParamSweepModel;
+import fiji.plugin.trackmate.helper.model.parameter.BooleanParamSweepModel.BooleanRangeType;
 import fiji.plugin.trackmate.helper.model.parameter.DoubleParamSweepModel;
 import fiji.plugin.trackmate.helper.model.parameter.EnumParamSweepModel;
 import fiji.plugin.trackmate.helper.model.parameter.IntParamSweepModel;
@@ -53,7 +55,7 @@ public class CellposeOpt
 				.add( System.getProperty( "user.home" ) );
 		final EnumParamSweepModel< PretrainedModelCellpose > cellposeModel = new EnumParamSweepModel<>( PretrainedModelCellpose.class )
 				.paramName( "Cellpose model" )
-				.rangeType( fiji.plugin.trackmate.helper.model.parameter.ArrayParamSweepModel.RangeType.FIXED )
+				.rangeType( ArrayRangeType.FIXED )
 				.addValue( PretrainedModelCellpose.CYTO )
 				.addValue( PretrainedModelCellpose.CYTO2 )
 				.fixedValue( PretrainedModelCellpose.CYTO );
@@ -79,11 +81,11 @@ public class CellposeOpt
 				.max( 50. );
 		final BooleanParamSweepModel useGPU = new BooleanParamSweepModel()
 				.paramName( "Use GPU" )
-				.rangeType( fiji.plugin.trackmate.helper.model.parameter.BooleanParamSweepModel.RangeType.FIXED )
+				.rangeType( BooleanRangeType.FIXED )
 				.fixedValue( true );
 		final BooleanParamSweepModel simplifyContours = new BooleanParamSweepModel()
 				.paramName( "Simplify contours" )
-				.rangeType( fiji.plugin.trackmate.helper.model.parameter.BooleanParamSweepModel.RangeType.FIXED )
+				.rangeType( BooleanRangeType.FIXED )
 				.fixedValue( true );
 
 		final Map< String, AbstractParamSweepModel< ? > > models = new LinkedHashMap<>();

--- a/src/main/java/fiji/plugin/trackmate/helper/model/detector/DogDetectorModel.java
+++ b/src/main/java/fiji/plugin/trackmate/helper/model/detector/DogDetectorModel.java
@@ -8,12 +8,12 @@
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-3.0.html>.
@@ -31,6 +31,7 @@ import fiji.plugin.trackmate.detection.DetectorKeys;
 import fiji.plugin.trackmate.detection.DogDetectorFactory;
 import fiji.plugin.trackmate.helper.model.parameter.AbstractParamSweepModel;
 import fiji.plugin.trackmate.helper.model.parameter.BooleanParamSweepModel;
+import fiji.plugin.trackmate.helper.model.parameter.BooleanParamSweepModel.BooleanRangeType;
 import fiji.plugin.trackmate.helper.model.parameter.DoubleParamSweepModel;
 import fiji.plugin.trackmate.helper.model.parameter.NumberParamSweepModel.RangeType;
 
@@ -58,11 +59,11 @@ public class DogDetectorModel extends DetectorSweepModel
 				.nSteps( 3 );
 		final BooleanParamSweepModel subpixelLocalization = new BooleanParamSweepModel()
 				.paramName( "Sub-pixel localization" )
-				.rangeType( BooleanParamSweepModel.RangeType.FIXED )
+				.rangeType( BooleanRangeType.FIXED )
 				.fixedValue( true );
 		final BooleanParamSweepModel useMedian = new BooleanParamSweepModel()
 				.paramName( "Median pre-processing" )
-				.rangeType( BooleanParamSweepModel.RangeType.FIXED )
+				.rangeType( BooleanRangeType.FIXED )
 				.fixedValue( false );
 
 		final Map< String, AbstractParamSweepModel< ? > > models = new LinkedHashMap<>();

--- a/src/main/java/fiji/plugin/trackmate/helper/model/detector/HessianDetectorModel.java
+++ b/src/main/java/fiji/plugin/trackmate/helper/model/detector/HessianDetectorModel.java
@@ -8,12 +8,12 @@
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-3.0.html>.
@@ -31,6 +31,7 @@ import fiji.plugin.trackmate.detection.DetectorKeys;
 import fiji.plugin.trackmate.detection.HessianDetectorFactory;
 import fiji.plugin.trackmate.helper.model.parameter.AbstractParamSweepModel;
 import fiji.plugin.trackmate.helper.model.parameter.BooleanParamSweepModel;
+import fiji.plugin.trackmate.helper.model.parameter.BooleanParamSweepModel.BooleanRangeType;
 import fiji.plugin.trackmate.helper.model.parameter.DoubleParamSweepModel;
 import fiji.plugin.trackmate.helper.model.parameter.NumberParamSweepModel.RangeType;
 
@@ -63,11 +64,11 @@ public class HessianDetectorModel extends DetectorSweepModel
 				.nSteps( 3 );
 		final BooleanParamSweepModel normalizeQuality = new BooleanParamSweepModel()
 				.paramName( "Normalize quality" )
-				.rangeType( BooleanParamSweepModel.RangeType.FIXED )
+				.rangeType( BooleanRangeType.FIXED )
 				.fixedValue( true );
 		final BooleanParamSweepModel subpixelLocalization = new BooleanParamSweepModel()
 				.paramName( "Sub-pixel localization" )
-				.rangeType( BooleanParamSweepModel.RangeType.FIXED )
+				.rangeType( BooleanRangeType.FIXED )
 				.fixedValue( true );
 
 		final Map< String, AbstractParamSweepModel< ? > > models = new LinkedHashMap<>();

--- a/src/main/java/fiji/plugin/trackmate/helper/model/detector/LabelImgDetectorModel.java
+++ b/src/main/java/fiji/plugin/trackmate/helper/model/detector/LabelImgDetectorModel.java
@@ -8,12 +8,12 @@
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-3.0.html>.
@@ -30,6 +30,7 @@ import fiji.plugin.trackmate.detection.LabelImageDetectorFactory;
 import fiji.plugin.trackmate.detection.ThresholdDetectorFactory;
 import fiji.plugin.trackmate.helper.model.parameter.AbstractParamSweepModel;
 import fiji.plugin.trackmate.helper.model.parameter.BooleanParamSweepModel;
+import fiji.plugin.trackmate.helper.model.parameter.BooleanParamSweepModel.BooleanRangeType;
 
 @Plugin( type = DetectorSweepModel.class, priority = 1000000 - 6 )
 public class LabelImgDetectorModel extends DetectorSweepModel
@@ -44,7 +45,7 @@ public class LabelImgDetectorModel extends DetectorSweepModel
 	{
 		final BooleanParamSweepModel simplifyContours = new BooleanParamSweepModel()
 				.paramName( "Simplify contours" )
-				.rangeType( fiji.plugin.trackmate.helper.model.parameter.BooleanParamSweepModel.RangeType.FIXED )
+				.rangeType( BooleanRangeType.FIXED )
 				.fixedValue( true );
 		final Map< String, AbstractParamSweepModel< ? > > models = new LinkedHashMap<>();
 		models.put( ThresholdDetectorFactory.KEY_SIMPLIFY_CONTOURS, simplifyContours );

--- a/src/main/java/fiji/plugin/trackmate/helper/model/detector/LogDetectorModel.java
+++ b/src/main/java/fiji/plugin/trackmate/helper/model/detector/LogDetectorModel.java
@@ -8,12 +8,12 @@
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-3.0.html>.
@@ -31,6 +31,7 @@ import fiji.plugin.trackmate.detection.DetectorKeys;
 import fiji.plugin.trackmate.detection.LogDetectorFactory;
 import fiji.plugin.trackmate.helper.model.parameter.AbstractParamSweepModel;
 import fiji.plugin.trackmate.helper.model.parameter.BooleanParamSweepModel;
+import fiji.plugin.trackmate.helper.model.parameter.BooleanParamSweepModel.BooleanRangeType;
 import fiji.plugin.trackmate.helper.model.parameter.DoubleParamSweepModel;
 import fiji.plugin.trackmate.helper.model.parameter.NumberParamSweepModel.RangeType;
 
@@ -58,11 +59,11 @@ public class LogDetectorModel extends DetectorSweepModel
 				.nSteps( 3 );
 		final BooleanParamSweepModel subpixelLocalization = new BooleanParamSweepModel()
 				.paramName( "Sub-pixel localization" )
-				.rangeType( BooleanParamSweepModel.RangeType.FIXED )
+				.rangeType( BooleanRangeType.FIXED )
 				.fixedValue( true );
 		final BooleanParamSweepModel useMedian = new BooleanParamSweepModel()
 				.paramName( "Median pre-processing" )
-				.rangeType( BooleanParamSweepModel.RangeType.FIXED )
+				.rangeType( BooleanRangeType.FIXED )
 				.fixedValue( false );
 
 		final Map< String, AbstractParamSweepModel< ? > > models = new LinkedHashMap<>();

--- a/src/main/java/fiji/plugin/trackmate/helper/model/detector/MaskDetectorModel.java
+++ b/src/main/java/fiji/plugin/trackmate/helper/model/detector/MaskDetectorModel.java
@@ -8,12 +8,12 @@
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-3.0.html>.
@@ -30,6 +30,7 @@ import fiji.plugin.trackmate.detection.MaskDetectorFactory;
 import fiji.plugin.trackmate.detection.ThresholdDetectorFactory;
 import fiji.plugin.trackmate.helper.model.parameter.AbstractParamSweepModel;
 import fiji.plugin.trackmate.helper.model.parameter.BooleanParamSweepModel;
+import fiji.plugin.trackmate.helper.model.parameter.BooleanParamSweepModel.BooleanRangeType;
 
 @Plugin( type = DetectorSweepModel.class, priority = 1000000 - 4 )
 public class MaskDetectorModel extends DetectorSweepModel
@@ -44,7 +45,7 @@ public class MaskDetectorModel extends DetectorSweepModel
 	{
 		final BooleanParamSweepModel simplifyContours = new BooleanParamSweepModel()
 				.paramName( "Simplify contours" )
-				.rangeType( fiji.plugin.trackmate.helper.model.parameter.BooleanParamSweepModel.RangeType.FIXED )
+				.rangeType( BooleanRangeType.FIXED )
 				.fixedValue( true );
 		final Map< String, AbstractParamSweepModel< ? > > models = new LinkedHashMap<>();
 		models.put( ThresholdDetectorFactory.KEY_SIMPLIFY_CONTOURS, simplifyContours );

--- a/src/main/java/fiji/plugin/trackmate/helper/model/detector/MorphoLibJOpt.java
+++ b/src/main/java/fiji/plugin/trackmate/helper/model/detector/MorphoLibJOpt.java
@@ -8,12 +8,12 @@
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-3.0.html>.
@@ -33,8 +33,10 @@ import fiji.plugin.trackmate.Settings;
 import fiji.plugin.trackmate.detection.SpotDetectorFactoryBase;
 import fiji.plugin.trackmate.detection.ThresholdDetectorFactory;
 import fiji.plugin.trackmate.helper.model.detector.DetectorSweepModel.ModelsIterator;
+import fiji.plugin.trackmate.helper.model.parameter.AbstractArrayParamSweepModel.ArrayRangeType;
 import fiji.plugin.trackmate.helper.model.parameter.AbstractParamSweepModel;
 import fiji.plugin.trackmate.helper.model.parameter.BooleanParamSweepModel;
+import fiji.plugin.trackmate.helper.model.parameter.BooleanParamSweepModel.BooleanRangeType;
 import fiji.plugin.trackmate.helper.model.parameter.DoubleParamSweepModel;
 import fiji.plugin.trackmate.helper.model.parameter.EnumParamSweepModel;
 import fiji.plugin.trackmate.helper.model.parameter.IntParamSweepModel;
@@ -63,12 +65,12 @@ public class MorphoLibJOpt
 				.nSteps( 3 );
 		final EnumParamSweepModel< Connectivity > connectivityParam = new EnumParamSweepModel<>( Connectivity.class )
 				.paramName( "Connectivity" )
-				.rangeType( fiji.plugin.trackmate.helper.model.parameter.ArrayParamSweepModel.RangeType.FIXED )
+				.rangeType( ArrayRangeType.FIXED )
 				.addValue( Connectivity.DIAGONAL )
 				.fixedValue( Connectivity.DIAGONAL );
 		final BooleanParamSweepModel simplifyContourParam = new BooleanParamSweepModel()
 				.paramName( "Simplify contours" )
-				.rangeType( BooleanParamSweepModel.RangeType.FIXED )
+				.rangeType( BooleanRangeType.FIXED )
 				.fixedValue( true );
 
 		final Map< String, AbstractParamSweepModel< ? > > models = new LinkedHashMap<>();

--- a/src/main/java/fiji/plugin/trackmate/helper/model/detector/OmniposeOpt.java
+++ b/src/main/java/fiji/plugin/trackmate/helper/model/detector/OmniposeOpt.java
@@ -8,12 +8,12 @@
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-3.0.html>.
@@ -29,8 +29,10 @@ import fiji.plugin.trackmate.cellpose.AbstractCellposeSettings.PretrainedModel;
 import fiji.plugin.trackmate.detection.DetectorKeys;
 import fiji.plugin.trackmate.detection.SpotDetectorFactoryBase;
 import fiji.plugin.trackmate.detection.ThresholdDetectorFactory;
+import fiji.plugin.trackmate.helper.model.parameter.AbstractArrayParamSweepModel.ArrayRangeType;
 import fiji.plugin.trackmate.helper.model.parameter.AbstractParamSweepModel;
 import fiji.plugin.trackmate.helper.model.parameter.BooleanParamSweepModel;
+import fiji.plugin.trackmate.helper.model.parameter.BooleanParamSweepModel.BooleanRangeType;
 import fiji.plugin.trackmate.helper.model.parameter.DoubleParamSweepModel;
 import fiji.plugin.trackmate.helper.model.parameter.EnumParamSweepModel;
 import fiji.plugin.trackmate.helper.model.parameter.IntParamSweepModel;
@@ -53,7 +55,7 @@ public class OmniposeOpt
 				.add( System.getProperty( "user.home" ) );
 		final EnumParamSweepModel< PretrainedModelOmnipose > omniposeModel = new EnumParamSweepModel<>( PretrainedModelOmnipose.class )
 				.paramName( "Omnipose model" )
-				.rangeType( fiji.plugin.trackmate.helper.model.parameter.ArrayParamSweepModel.RangeType.FIXED )
+				.rangeType( ArrayRangeType.FIXED )
 				.addValue( PretrainedModelOmnipose.BACT_PHASE )
 				.addValue( PretrainedModelOmnipose.BACT_FLUO )
 				.fixedValue( PretrainedModelOmnipose.BACT_PHASE );
@@ -79,11 +81,11 @@ public class OmniposeOpt
 				.max( 50. );
 		final BooleanParamSweepModel useGPU = new BooleanParamSweepModel()
 				.paramName( "Use GPU" )
-				.rangeType( fiji.plugin.trackmate.helper.model.parameter.BooleanParamSweepModel.RangeType.FIXED )
+				.rangeType( BooleanRangeType.FIXED )
 				.fixedValue( true );
 		final BooleanParamSweepModel simplifyContours = new BooleanParamSweepModel()
 				.paramName( "Simplify contours" )
-				.rangeType( fiji.plugin.trackmate.helper.model.parameter.BooleanParamSweepModel.RangeType.FIXED )
+				.rangeType( BooleanRangeType.FIXED )
 				.fixedValue( true );
 
 		final Map< String, AbstractParamSweepModel< ? > > models = new LinkedHashMap<>();

--- a/src/main/java/fiji/plugin/trackmate/helper/model/detector/ThresholdDetectorModel.java
+++ b/src/main/java/fiji/plugin/trackmate/helper/model/detector/ThresholdDetectorModel.java
@@ -8,12 +8,12 @@
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-3.0.html>.
@@ -29,6 +29,7 @@ import org.scijava.plugin.Plugin;
 import fiji.plugin.trackmate.detection.ThresholdDetectorFactory;
 import fiji.plugin.trackmate.helper.model.parameter.AbstractParamSweepModel;
 import fiji.plugin.trackmate.helper.model.parameter.BooleanParamSweepModel;
+import fiji.plugin.trackmate.helper.model.parameter.BooleanParamSweepModel.BooleanRangeType;
 import fiji.plugin.trackmate.helper.model.parameter.DoubleParamSweepModel;
 import fiji.plugin.trackmate.helper.model.parameter.NumberParamSweepModel.RangeType;
 
@@ -45,7 +46,7 @@ public class ThresholdDetectorModel extends DetectorSweepModel
 	{
 		final BooleanParamSweepModel simplifyContours = new BooleanParamSweepModel()
 				.paramName( "Simplify contours" )
-				.rangeType( fiji.plugin.trackmate.helper.model.parameter.BooleanParamSweepModel.RangeType.FIXED )
+				.rangeType( BooleanRangeType.FIXED )
 				.fixedValue( true );
 		final DoubleParamSweepModel intensityThreshold = new DoubleParamSweepModel()
 				.paramName( "Intensity threshold" )

--- a/src/main/java/fiji/plugin/trackmate/helper/model/detector/YOLOOpt.java
+++ b/src/main/java/fiji/plugin/trackmate/helper/model/detector/YOLOOpt.java
@@ -21,18 +21,14 @@
  */
 package fiji.plugin.trackmate.helper.model.detector;
 
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 
 import fiji.plugin.trackmate.detection.SpotDetectorFactoryBase;
 import fiji.plugin.trackmate.helper.model.parameter.AbstractParamSweepModel;
-import fiji.plugin.trackmate.helper.model.parameter.ArrayParamSweepModel;
+import fiji.plugin.trackmate.helper.model.parameter.CondaEnvParamSweepModel;
 import fiji.plugin.trackmate.helper.model.parameter.DoubleParamSweepModel;
-import fiji.plugin.trackmate.helper.model.parameter.InfoParamSweepModel;
 import fiji.plugin.trackmate.helper.model.parameter.StringRangeParamSweepModel;
-import fiji.plugin.trackmate.util.cli.CLIUtils;
 import fiji.plugin.trackmate.yolo.YOLOCLI;
 import fiji.plugin.trackmate.yolo.YOLODetectorFactory;
 
@@ -44,34 +40,11 @@ public class YOLOOpt
 
 	static Map< String, AbstractParamSweepModel< ? > > createModels()
 	{
-		final Map< String, AbstractParamSweepModel< ? > > models = new LinkedHashMap<>();
-		final List< String > envList = new ArrayList<>();
-		try
-		{
-			final List< String > l = CLIUtils.getEnvList();
-			envList.addAll( l );
-		}
-		catch ( final Exception e )
-		{
-			e.printStackTrace();
-		}
-		if ( envList == null || envList.isEmpty() )
-		{
-			models.put( "", new InfoParamSweepModel()
-					.info( "The conda executable seems not to be configured, <br>"
-							+ "or no conda environment could be found. Please <br>"
-							+ "follow the link below for installation instructions." )
-					.url( "https://imagej.net/plugins/trackmate/detectors/trackmate-yolo" ) );
-			return models;
-		}
 
 		final YOLOCLI cli = new YOLOCLI();
 
-		final ArrayParamSweepModel< String > condaEnv = new ArrayParamSweepModel<>(
-				envList.toArray( new String[] {} ) )
-						.paramName( "YOLO conda environment" )
-						.addValue( envList.get( 0 ) )
-						.fixedValue( envList.get( 0 ) );
+		final CondaEnvParamSweepModel condaEnv = new CondaEnvParamSweepModel()
+				.paramName( "YOLO conda environment" );
 
 		final StringRangeParamSweepModel modelPath = new StringRangeParamSweepModel()
 				.paramName( cli.modelPath().getName() )
@@ -90,6 +63,7 @@ public class YOLOOpt
 				.max( 0.5 )
 				.nSteps( 5 );
 
+		final Map< String, AbstractParamSweepModel< ? > > models = new LinkedHashMap<>();
 		models.put( YOLOCLI.KEY_CONDA_ENV, condaEnv );
 		models.put( YOLODetectorFactory.KEY_YOLO_MODEL_FILEPATH, modelPath );
 		models.put( YOLODetectorFactory.KEY_YOLO_CONF, confidenceParam );

--- a/src/main/java/fiji/plugin/trackmate/helper/model/filter/FilterSweepModel.java
+++ b/src/main/java/fiji/plugin/trackmate/helper/model/filter/FilterSweepModel.java
@@ -11,12 +11,13 @@ import fiji.plugin.trackmate.Settings;
 import fiji.plugin.trackmate.features.FeatureFilter;
 import fiji.plugin.trackmate.gui.displaysettings.DisplaySettings.TrackMateObject;
 import fiji.plugin.trackmate.helper.model.AbstractSweepModelBase;
+import fiji.plugin.trackmate.helper.model.parameter.AbstractArrayParamSweepModel.ArrayRangeType;
 import fiji.plugin.trackmate.helper.model.parameter.AbstractParamSweepModel;
 import fiji.plugin.trackmate.helper.model.parameter.ArrayParamSweepModel;
 import fiji.plugin.trackmate.helper.model.parameter.BooleanParamSweepModel;
+import fiji.plugin.trackmate.helper.model.parameter.BooleanParamSweepModel.BooleanRangeType;
 import fiji.plugin.trackmate.helper.model.parameter.Combinations;
 import fiji.plugin.trackmate.helper.model.parameter.DoubleParamSweepModel;
-import fiji.plugin.trackmate.helper.model.parameter.NumberParamSweepModel;
 import fiji.plugin.trackmate.helper.model.parameter.NumberParamSweepModel.RangeType;
 
 public class FilterSweepModel extends AbstractSweepModelBase implements Iterable< FeatureFilter >
@@ -42,7 +43,7 @@ public class FilterSweepModel extends AbstractSweepModelBase implements Iterable
 
 	/**
 	 * Sets this model to represent the single feature filter specified.
-	 * 
+	 *
 	 * @param ff
 	 *            the feature filter.
 	 */
@@ -55,11 +56,11 @@ public class FilterSweepModel extends AbstractSweepModelBase implements Iterable
 
 		featureParam
 				.fixedValue( ff.feature )
-				.rangeType( ArrayParamSweepModel.RangeType.FIXED );
+				.rangeType( ArrayRangeType.FIXED );
 		thresholdParam.rangeType( RangeType.FIXED )
 				.min( ff.value );
 		isAboveParam.fixedValue( ff.isAbove )
-				.rangeType( BooleanParamSweepModel.RangeType.FIXED );
+				.rangeType( BooleanRangeType.FIXED );
 	}
 
 	@Override
@@ -80,18 +81,18 @@ public class FilterSweepModel extends AbstractSweepModelBase implements Iterable
 		final ArrayParamSweepModel< String > featureNameParam = new ArrayParamSweepModel<>( arr )
 				.paramName( "Feature " + index )
 				.fixedValue( arr[ 0 ] )
-				.rangeType( ArrayParamSweepModel.RangeType.FIXED );
+				.rangeType( ArrayRangeType.FIXED );
 
 		final DoubleParamSweepModel thresholdParam = new DoubleParamSweepModel()
 				.paramName( "Threshold" )
 				.dimension( Dimension.NONE )
-				.rangeType( NumberParamSweepModel.RangeType.FIXED )
+				.rangeType( RangeType.FIXED )
 				.min( 5. );
 
 		final BooleanParamSweepModel isAboveParam = new BooleanParamSweepModel()
 				.paramName( "Above?" )
 				.fixedValue( true )
-				.rangeType( BooleanParamSweepModel.RangeType.FIXED );
+				.rangeType( BooleanRangeType.FIXED );
 
 		final Map< String, AbstractParamSweepModel< ? > > models = new LinkedHashMap<>();
 		models.put( FEATURE, featureNameParam );
@@ -99,7 +100,7 @@ public class FilterSweepModel extends AbstractSweepModelBase implements Iterable
 		models.put( ISABOVE, isAboveParam );
 		return models;
 	}
-	
+
 	private static class FeatureFilterIterator implements Iterator< FeatureFilter >
 	{
 

--- a/src/main/java/fiji/plugin/trackmate/helper/model/parameter/AbstractArrayParamSweepModel.java
+++ b/src/main/java/fiji/plugin/trackmate/helper/model/parameter/AbstractArrayParamSweepModel.java
@@ -33,21 +33,15 @@ public class AbstractArrayParamSweepModel< T, F extends AbstractArrayParamSweepM
 
 	protected final Set< T > set = new LinkedHashSet<>();
 
-	protected RangeType rangeType = RangeType.FIXED;
+	protected ArrayRangeType rangeType = ArrayRangeType.FIXED;
 
 	protected T fixedValue;
 
-	private T[] allValues;
-
-	private AbstractArrayParamSweepModel()
-	{
-		super();
-	}
+	protected final List< T > allValues = new ArrayList<>();
 
 	public AbstractArrayParamSweepModel( final T[] allValues )
 	{
-		this();
-		this.allValues = allValues;
+		this.allValues.addAll( Arrays.asList( allValues ) );
 	}
 
 	@Override
@@ -66,7 +60,7 @@ public class AbstractArrayParamSweepModel< T, F extends AbstractArrayParamSweepM
 		}
 	}
 
-	public RangeType getRangeType()
+	public ArrayRangeType getRangeType()
 	{
 		return rangeType;
 	}
@@ -89,7 +83,7 @@ public class AbstractArrayParamSweepModel< T, F extends AbstractArrayParamSweepM
 	}
 
 	@SuppressWarnings( "unchecked" )
-	public F rangeType( final RangeType rangeType )
+	public F rangeType( final ArrayRangeType rangeType )
 	{
 		if ( this.rangeType != rangeType )
 		{
@@ -130,7 +124,7 @@ public class AbstractArrayParamSweepModel< T, F extends AbstractArrayParamSweepM
 
 	public List< T > getAllValues()
 	{
-		return Arrays.asList( allValues );
+		return allValues;
 	}
 
 	@Override
@@ -158,13 +152,13 @@ public class AbstractArrayParamSweepModel< T, F extends AbstractArrayParamSweepM
 		}
 	}
 
-	public enum RangeType
+	public enum ArrayRangeType
 	{
 		TEST_ALL( "test all" ), FIXED( "single value" ), LIST( "list" );
 
 		private final String name;
 
-		RangeType( final String name )
+		ArrayRangeType( final String name )
 		{
 			this.name = name;
 		}

--- a/src/main/java/fiji/plugin/trackmate/helper/model/parameter/AbstractArrayParamSweepModel.java
+++ b/src/main/java/fiji/plugin/trackmate/helper/model/parameter/AbstractArrayParamSweepModel.java
@@ -1,0 +1,178 @@
+/*-
+ * #%L
+ * TrackMate: your buddy for everyday tracking.
+ * %%
+ * Copyright (C) 2021 - 2024 TrackMate developers.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+package fiji.plugin.trackmate.helper.model.parameter;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+public class AbstractArrayParamSweepModel< T, F extends AbstractArrayParamSweepModel< T, F > > extends AbstractParamSweepModel< T >
+{
+
+	protected final Set< T > set = new LinkedHashSet<>();
+
+	protected RangeType rangeType = RangeType.FIXED;
+
+	protected T fixedValue;
+
+	private T[] allValues;
+
+	private AbstractArrayParamSweepModel()
+	{
+		super();
+	}
+
+	public AbstractArrayParamSweepModel( final T[] allValues )
+	{
+		this();
+		this.allValues = allValues;
+	}
+
+	@Override
+	public List< T > getRange()
+	{
+		switch ( rangeType )
+		{
+		case FIXED:
+			return Collections.singletonList( fixedValue );
+		case LIST:
+			return new ArrayList<>( set );
+		case TEST_ALL:
+			return getAllValues();
+		default:
+			throw new IllegalArgumentException( "Unknown range type: " + rangeType );
+		}
+	}
+
+	public RangeType getRangeType()
+	{
+		return rangeType;
+	}
+
+	public T getFixedValue()
+	{
+		return fixedValue;
+	}
+
+	public Set< T > getSelection()
+	{
+		return set;
+	}
+
+	@SuppressWarnings( "unchecked" )
+	@Override
+	public F paramName( final String paramName )
+	{
+		return ( F ) super.paramName( paramName );
+	}
+
+	@SuppressWarnings( "unchecked" )
+	public F rangeType( final RangeType rangeType )
+	{
+		if ( this.rangeType != rangeType )
+		{
+			this.rangeType = rangeType;
+			notifyListeners();
+		}
+		return ( F ) this;
+	}
+
+	@SuppressWarnings( "unchecked" )
+	public F fixedValue( final T fixedValue )
+	{
+		if ( this.fixedValue != fixedValue )
+		{
+			this.fixedValue = fixedValue;
+			notifyListeners();
+		}
+		return ( F ) this;
+	}
+
+	@SuppressWarnings( "unchecked" )
+	public F addValue( final T value )
+	{
+		if ( set.add( value ) )
+			notifyListeners();
+
+		return ( F ) this;
+	}
+
+	@SuppressWarnings( "unchecked" )
+	public F removeValue( final T value )
+	{
+		if ( set.remove( value ) )
+			notifyListeners();
+
+		return ( F ) this;
+	}
+
+	public List< T > getAllValues()
+	{
+		return Arrays.asList( allValues );
+	}
+
+	@Override
+	public String toString()
+	{
+		switch ( rangeType )
+		{
+		case FIXED:
+			return String.format( "%s:\n"
+					+ " - type: %s\n"
+					+ " - value: %s",
+					paramName,
+					rangeType,
+					fixedValue );
+		case LIST:
+		case TEST_ALL:
+			return String.format( "%s:\n"
+					+ " - type: %s\n"
+					+ " - values: %s",
+					paramName,
+					rangeType,
+					Arrays.toString( getRange().toArray() ) );
+		default:
+			throw new IllegalArgumentException( "Unknown range type: " + rangeType );
+		}
+	}
+
+	public enum RangeType
+	{
+		TEST_ALL( "test all" ), FIXED( "single value" ), LIST( "list" );
+
+		private final String name;
+
+		RangeType( final String name )
+		{
+			this.name = name;
+		}
+
+		@Override
+		public String toString()
+		{
+			return name;
+		}
+	}
+}

--- a/src/main/java/fiji/plugin/trackmate/helper/model/parameter/AbstractParamSweepModel.java
+++ b/src/main/java/fiji/plugin/trackmate/helper/model/parameter/AbstractParamSweepModel.java
@@ -8,12 +8,12 @@
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-3.0.html>.
@@ -30,16 +30,11 @@ import fiji.plugin.trackmate.helper.model.AbstractSweepModelBase.ModelListener;
 public abstract class AbstractParamSweepModel< T >
 {
 
-	public abstract List< T > getRange();
-
-	private final transient Listeners.List< ModelListener > modelListeners;
+	private transient Listeners.List< ModelListener > modelListeners = new Listeners.SynchronizedList<>();
 
 	protected String paramName = " ";
 
-	public AbstractParamSweepModel()
-	{
-		this.modelListeners = new Listeners.SynchronizedList<>();
-	}
+	public abstract List< T > getRange();
 
 	public AbstractParamSweepModel< T > paramName( final String paramName )
 	{
@@ -65,5 +60,13 @@ public abstract class AbstractParamSweepModel< T >
 	{
 		for ( final ModelListener l : modelListeners.list )
 			l.modelChanged();
+	}
+
+	/**
+	 * For deserialization only!
+	 */
+	void initialize()
+	{
+		modelListeners = new Listeners.SynchronizedList<>();
 	}
 }

--- a/src/main/java/fiji/plugin/trackmate/helper/model/parameter/AbstractParamSweepModelIO.java
+++ b/src/main/java/fiji/plugin/trackmate/helper/model/parameter/AbstractParamSweepModelIO.java
@@ -1,0 +1,43 @@
+package fiji.plugin.trackmate.helper.model.parameter;
+
+import java.lang.reflect.Type;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+public class AbstractParamSweepModelIO implements JsonSerializer< AbstractParamSweepModel< ? > >, JsonDeserializer< AbstractParamSweepModel< ? > >
+{
+
+	@Override
+	public AbstractParamSweepModel< ? > deserialize( final JsonElement json, final Type typeOfT, final JsonDeserializationContext context ) throws JsonParseException
+	{
+		final JsonObject jsonObject = json.getAsJsonObject();
+		final String type = jsonObject.get( "type" ).getAsString();
+		final JsonElement element = jsonObject.get( "properties" );
+		try
+		{
+			final AbstractParamSweepModel< ? > deserialized = context.deserialize( element, Class.forName( "fiji.plugin.trackmate.helper.model.parameter." + type ) );
+			deserialized.initialize();
+			return deserialized;
+		}
+		catch ( final ClassNotFoundException cnfe )
+		{
+			throw new JsonParseException( "Unknown element type: " + type, cnfe );
+		}
+	}
+
+	@Override
+	public JsonElement serialize( final AbstractParamSweepModel< ? > src, final Type typeOfSrc, final JsonSerializationContext context )
+	{
+		final JsonObject result = new JsonObject();
+		result.add( "type", new JsonPrimitive( src.getClass().getSimpleName() ) );
+		result.add( "properties", context.serialize( src, src.getClass() ) );
+		return result;
+	}
+}

--- a/src/main/java/fiji/plugin/trackmate/helper/model/parameter/ArrayParamSweepModel.java
+++ b/src/main/java/fiji/plugin/trackmate/helper/model/parameter/ArrayParamSweepModel.java
@@ -8,12 +8,12 @@
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-3.0.html>.
@@ -21,153 +21,11 @@
  */
 package fiji.plugin.trackmate.helper.model.parameter;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
-
-public class ArrayParamSweepModel< T > extends AbstractParamSweepModel< T >
+public class ArrayParamSweepModel< T > extends AbstractArrayParamSweepModel< T, ArrayParamSweepModel< T > >
 {
-
-	protected final Set< T > set = new LinkedHashSet<>();
-
-	protected RangeType rangeType = RangeType.FIXED;
-
-	protected T fixedValue;
-
-	private T[] allValues;
-
-	private ArrayParamSweepModel()
-	{
-		super();
-	}
 
 	public ArrayParamSweepModel( final T[] allValues )
 	{
-		this();
-		this.allValues = allValues;
-	}
-
-	@Override
-	public List< T > getRange()
-	{
-		switch ( rangeType )
-		{
-		case FIXED:
-			return Collections.singletonList( fixedValue );
-		case LIST:
-			return new ArrayList<>( set );
-		case TEST_ALL:
-			return getAllValues();
-		default:
-			throw new IllegalArgumentException( "Unknown range type: " + rangeType );
-		}
-	}
-
-	public RangeType getRangeType()
-	{
-		return rangeType;
-	}
-
-	public T getFixedValue()
-	{
-		return fixedValue;
-	}
-
-	public Set< T > getSelection()
-	{
-		return set;
-	}
-
-	@Override
-	public ArrayParamSweepModel< T > paramName( final String paramName )
-	{
-		return ( ArrayParamSweepModel< T > ) super.paramName( paramName );
-	}
-
-	public ArrayParamSweepModel< T > rangeType( final RangeType rangeType )
-	{
-		if ( this.rangeType != rangeType )
-		{
-			this.rangeType = rangeType;
-			notifyListeners();
-		}
-		return this;
-	}
-
-	public ArrayParamSweepModel< T > fixedValue( final T fixedValue )
-	{
-		if ( this.fixedValue != fixedValue )
-		{
-			this.fixedValue = fixedValue;
-			notifyListeners();
-		}
-		return this;
-	}
-
-	public ArrayParamSweepModel< T > addValue( final T value )
-	{
-		if ( set.add( value ) )
-			notifyListeners();
-	
-		return this;
-	}
-
-	public ArrayParamSweepModel< T > removeValue( final T value )
-	{
-		if ( set.remove( value ) )
-			notifyListeners();
-	
-		return this;
-	}
-
-	public List< T > getAllValues()
-	{
-		return Arrays.asList( allValues );
-	}
-
-	@Override
-	public String toString()
-	{
-		switch ( rangeType )
-		{
-		case FIXED:
-			return String.format( "%s:\n"
-					+ " - type: %s\n"
-					+ " - value: %s",
-					paramName,
-					rangeType,
-					fixedValue );
-		case LIST:
-		case TEST_ALL:
-			return String.format( "%s:\n"
-					+ " - type: %s\n"
-					+ " - values: %s",
-					paramName,
-					rangeType,
-					Arrays.toString( getRange().toArray() ) );
-		default:
-			throw new IllegalArgumentException( "Unknown range type: " + rangeType );
-		}
-	}
-
-	public enum RangeType
-	{
-		TEST_ALL( "test all" ), FIXED( "single value" ), LIST( "list" );
-
-		private final String name;
-
-		RangeType( final String name )
-		{
-			this.name = name;
-		}
-
-		@Override
-		public String toString()
-		{
-			return name;
-		}
+		super( allValues );
 	}
 }

--- a/src/main/java/fiji/plugin/trackmate/helper/model/parameter/BooleanParamSweepModel.java
+++ b/src/main/java/fiji/plugin/trackmate/helper/model/parameter/BooleanParamSweepModel.java
@@ -28,13 +28,13 @@ import java.util.List;
 public class BooleanParamSweepModel extends AbstractParamSweepModel< Boolean >
 {
 
-	public enum RangeType
+	public enum BooleanRangeType
 	{
 		TEST_ALL( "test both" ), FIXED( "fixed value" );
 
 		private final String name;
 
-		RangeType( final String name )
+		BooleanRangeType( final String name )
 		{
 			this.name = name;
 		}
@@ -46,7 +46,7 @@ public class BooleanParamSweepModel extends AbstractParamSweepModel< Boolean >
 		}
 	}
 
-	private RangeType rangeType = RangeType.TEST_ALL;
+	private BooleanRangeType rangeType = BooleanRangeType.TEST_ALL;
 
 	private boolean fixedValue = true;
 
@@ -69,7 +69,7 @@ public class BooleanParamSweepModel extends AbstractParamSweepModel< Boolean >
 		return fixedValue;
 	}
 
-	public RangeType getRangeType()
+	public BooleanRangeType getRangeType()
 	{
 		return rangeType;
 	}
@@ -102,7 +102,7 @@ public class BooleanParamSweepModel extends AbstractParamSweepModel< Boolean >
 		return ( BooleanParamSweepModel ) super.paramName( paramName );
 	}
 
-	public BooleanParamSweepModel rangeType( final RangeType rangeType )
+	public BooleanParamSweepModel rangeType( final BooleanRangeType rangeType )
 	{
 		if ( this.rangeType != rangeType )
 		{

--- a/src/main/java/fiji/plugin/trackmate/helper/model/parameter/CondaEnvParamSweepModel.java
+++ b/src/main/java/fiji/plugin/trackmate/helper/model/parameter/CondaEnvParamSweepModel.java
@@ -10,7 +10,7 @@ public class CondaEnvParamSweepModel extends AbstractArrayParamSweepModel< Strin
 
 	public CondaEnvParamSweepModel()
 	{
-		super( getEnvList() );
+		super( getEnvList().toArray( new String[] {} ) );
 		final List< String > allEnvs = getAllValues();
 		if ( allEnvs != null && !allEnvs.isEmpty() )
 		{
@@ -19,7 +19,7 @@ public class CondaEnvParamSweepModel extends AbstractArrayParamSweepModel< Strin
 		}
 	}
 
-	protected static final String[] getEnvList()
+	protected static final List< String > getEnvList()
 	{
 		final List< String > envList = new ArrayList<>();
 		try
@@ -31,8 +31,17 @@ public class CondaEnvParamSweepModel extends AbstractArrayParamSweepModel< Strin
 		{
 			e.printStackTrace();
 		}
-		return envList.toArray( new String[] {} );
+		return envList;
 	}
+
+	@Override
+	void initialize()
+	{
+		super.initialize();
+		allValues.clear();
+		allValues.addAll( getEnvList() );
+	}
+
 //	if ( envList == null || envList.isEmpty() )
 //	{
 //		models.put( "", new InfoParamSweepModel()

--- a/src/main/java/fiji/plugin/trackmate/helper/model/parameter/CondaEnvParamSweepModel.java
+++ b/src/main/java/fiji/plugin/trackmate/helper/model/parameter/CondaEnvParamSweepModel.java
@@ -1,0 +1,45 @@
+package fiji.plugin.trackmate.helper.model.parameter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import fiji.plugin.trackmate.util.cli.CLIUtils;
+
+public class CondaEnvParamSweepModel extends AbstractArrayParamSweepModel< String, CondaEnvParamSweepModel >
+{
+
+	public CondaEnvParamSweepModel()
+	{
+		super( getEnvList() );
+		final List< String > allEnvs = getAllValues();
+		if ( allEnvs != null && !allEnvs.isEmpty() )
+		{
+			addValue( allEnvs.get( 0 ) );
+			fixedValue( allEnvs.get( 0 ) );
+		}
+	}
+
+	protected static final String[] getEnvList()
+	{
+		final List< String > envList = new ArrayList<>();
+		try
+		{
+			final List< String > l = CLIUtils.getEnvList();
+			envList.addAll( l );
+		}
+		catch ( final Exception e )
+		{
+			e.printStackTrace();
+		}
+		return envList.toArray( new String[] {} );
+	}
+//	if ( envList == null || envList.isEmpty() )
+//	{
+//		models.put( "", new InfoParamSweepModel()
+//				.info( "The conda executable seems not to be configured, <br>"
+//						+ "or no conda environment could be found. Please <br>"
+//						+ "follow the link below for installation instructions." )
+//				.url( "https://imagej.net/plugins/trackmate/trackers/trackmate-trackastra" ) );
+//		return models;
+//	}
+}

--- a/src/main/java/fiji/plugin/trackmate/helper/model/parameter/EnumParamSweepModel.java
+++ b/src/main/java/fiji/plugin/trackmate/helper/model/parameter/EnumParamSweepModel.java
@@ -40,7 +40,7 @@ public class EnumParamSweepModel< T extends Enum< T > > extends ArrayParamSweepM
 	}
 
 	@Override
-	public EnumParamSweepModel< T > rangeType( final RangeType rangeType )
+	public EnumParamSweepModel< T > rangeType( final ArrayRangeType rangeType )
 	{
 		if ( this.rangeType != rangeType )
 		{

--- a/src/main/java/fiji/plugin/trackmate/helper/model/tracker/LAPTrackerModel.java
+++ b/src/main/java/fiji/plugin/trackmate/helper/model/tracker/LAPTrackerModel.java
@@ -8,12 +8,12 @@
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-3.0.html>.
@@ -29,6 +29,7 @@ import org.scijava.plugin.Plugin;
 import fiji.plugin.trackmate.Dimension;
 import fiji.plugin.trackmate.helper.model.parameter.AbstractParamSweepModel;
 import fiji.plugin.trackmate.helper.model.parameter.BooleanParamSweepModel;
+import fiji.plugin.trackmate.helper.model.parameter.BooleanParamSweepModel.BooleanRangeType;
 import fiji.plugin.trackmate.helper.model.parameter.DoubleParamSweepModel;
 import fiji.plugin.trackmate.helper.model.parameter.IntParamSweepModel;
 import fiji.plugin.trackmate.helper.model.parameter.NumberParamSweepModel.RangeType;
@@ -57,7 +58,7 @@ public class LAPTrackerModel extends TrackerSweepModel
 		final BooleanParamSweepModel allowGapClosingParam = new BooleanParamSweepModel()
 				.paramName( "Allow gap-closing" )
 				.fixedValue( true )
-				.rangeType( fiji.plugin.trackmate.helper.model.parameter.BooleanParamSweepModel.RangeType.FIXED );
+				.rangeType( BooleanRangeType.FIXED );
 		final DoubleParamSweepModel gapClosingDistanceParam = new DoubleParamSweepModel()
 				.paramName( "Gap-closing distance" )
 				.dimension( Dimension.LENGTH )
@@ -73,7 +74,7 @@ public class LAPTrackerModel extends TrackerSweepModel
 		final BooleanParamSweepModel allowTrackSplittingParam = new BooleanParamSweepModel()
 				.paramName( "Allow track splitting" )
 				.fixedValue( true )
-				.rangeType( fiji.plugin.trackmate.helper.model.parameter.BooleanParamSweepModel.RangeType.FIXED );
+				.rangeType( BooleanRangeType.FIXED );
 		final DoubleParamSweepModel splittingMaxDistanceParam = new DoubleParamSweepModel()
 				.paramName( "Splitting max distance" )
 				.dimension( Dimension.LENGTH )
@@ -85,7 +86,7 @@ public class LAPTrackerModel extends TrackerSweepModel
 		final BooleanParamSweepModel allowTrackMergingParam = new BooleanParamSweepModel()
 				.paramName( "Allow track merging" )
 				.fixedValue( true )
-				.rangeType( fiji.plugin.trackmate.helper.model.parameter.BooleanParamSweepModel.RangeType.FIXED );
+				.rangeType( BooleanRangeType.FIXED );
 		final DoubleParamSweepModel mergingMaxDistanceParam = new DoubleParamSweepModel()
 				.paramName( "Merging max distance" )
 				.dimension( Dimension.LENGTH )

--- a/src/main/java/fiji/plugin/trackmate/helper/model/tracker/OverlapTrackerModel.java
+++ b/src/main/java/fiji/plugin/trackmate/helper/model/tracker/OverlapTrackerModel.java
@@ -8,12 +8,12 @@
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-3.0.html>.
@@ -28,11 +28,12 @@ import java.util.stream.Collectors;
 
 import org.scijava.plugin.Plugin;
 
-import fiji.plugin.trackmate.tracking.overlap.OverlapTracker.IoUCalculation;
+import fiji.plugin.trackmate.helper.model.parameter.AbstractArrayParamSweepModel.ArrayRangeType;
 import fiji.plugin.trackmate.helper.model.parameter.AbstractParamSweepModel;
 import fiji.plugin.trackmate.helper.model.parameter.ArrayParamSweepModel;
 import fiji.plugin.trackmate.helper.model.parameter.DoubleParamSweepModel;
 import fiji.plugin.trackmate.helper.model.parameter.NumberParamSweepModel.RangeType;
+import fiji.plugin.trackmate.tracking.overlap.OverlapTracker.IoUCalculation;
 import fiji.plugin.trackmate.tracking.overlap.OverlapTrackerFactory;
 
 @Plugin( type = TrackerSweepModel.class, priority = 1000000 - 4 )
@@ -65,7 +66,7 @@ public class OverlapTrackerModel extends TrackerSweepModel
 				.paramName( "IoU calculation" )
 				.fixedValue( IoUCalculation.PRECISE.name() )
 				.addValue( IoUCalculation.PRECISE.name() )
-				.rangeType( fiji.plugin.trackmate.helper.model.parameter.ArrayParamSweepModel.RangeType.FIXED );
+				.rangeType( ArrayRangeType.FIXED );
 
 		final Map< String, AbstractParamSweepModel< ? > > models = new LinkedHashMap<>();
 		models.put( OverlapTrackerFactory.KEY_SCALE_FACTOR, scaleFactorParam );

--- a/src/main/java/fiji/plugin/trackmate/helper/model/tracker/TrackastraOpt.java
+++ b/src/main/java/fiji/plugin/trackmate/helper/model/tracker/TrackastraOpt.java
@@ -21,19 +21,16 @@
  */
 package fiji.plugin.trackmate.helper.model.tracker;
 
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 
 import fiji.plugin.trackmate.helper.model.parameter.AbstractParamSweepModel;
 import fiji.plugin.trackmate.helper.model.parameter.ArrayParamSweepModel;
-import fiji.plugin.trackmate.helper.model.parameter.InfoParamSweepModel;
+import fiji.plugin.trackmate.helper.model.parameter.CondaEnvParamSweepModel;
 import fiji.plugin.trackmate.helper.model.parameter.StringRangeParamSweepModel;
 import fiji.plugin.trackmate.tracking.SpotTrackerFactory;
 import fiji.plugin.trackmate.tracking.trackastra.TrackastraCLI;
 import fiji.plugin.trackmate.tracking.trackastra.TrackastraTrackerFactory;
-import fiji.plugin.trackmate.util.cli.CLIUtils;
 
 public class TrackastraOpt
 {
@@ -43,48 +40,28 @@ public class TrackastraOpt
 
 	static Map< String, AbstractParamSweepModel< ? > > createModels()
 	{
-		final Map< String, AbstractParamSweepModel< ? > > models = new LinkedHashMap<>();
-		final List< String > envList = new ArrayList<>();
-		try
-		{
-			final List< String > l = CLIUtils.getEnvList();
-			envList.addAll( l );
-		}
-		catch ( final Exception e )
-		{
-			e.printStackTrace();
-		}
-		if ( envList == null || envList.isEmpty() )
-		{
-			models.put( "", new InfoParamSweepModel()
-					.info( "The conda executable seems not to be configured, <br>"
-							+ "or no conda environment could be found. Please <br>"
-							+ "follow the link below for installation instructions." )
-					.url( "https://imagej.net/plugins/trackmate/trackers/trackmate-trackastra" ) );
-			return models;
-		}
+		final CondaEnvParamSweepModel condaEnv = new CondaEnvParamSweepModel()
+				.paramName( "Trackastra conda environment" );
 
-		final ArrayParamSweepModel< String > condaEnv = new ArrayParamSweepModel<>(
-				envList.toArray( new String[] {} ) )
-						.paramName( "Trackastra conda environment" )
-						.addValue( envList.get( 0 ) )
-						.fixedValue( envList.get( 0 ) );
 		final ArrayParamSweepModel< String > pretrainedModel = new ArrayParamSweepModel<>( new String[] {
 				"general_2d",
 				"ctc" } )
 						.paramName( "Pretrained model" )
 						.addValue( "general_2d" )
 						.fixedValue( "general_2d" );
+
 		final ArrayParamSweepModel< String > pretrainedOrCustom = new ArrayParamSweepModel<>( new String[] {
 				"PRETRAINED_MODEL",
 				"CUSTOM_MODEL_PATH" } )
 						.paramName( "Use pretrained or custom model" )
 						.addValue( "PRETRAINED_MODEL" )
 						.fixedValue( "PRETRAINED_MODEL" );
+
 		final StringRangeParamSweepModel customModelPath = new StringRangeParamSweepModel()
 				.paramName( "Trackastra custom model path" )
 				.isFile( true )
 				.add( System.getProperty( "user.home" ) );
+
 		final ArrayParamSweepModel< String > trackingMode = new ArrayParamSweepModel<>( new String[] {
 				"greedy_nodiv",
 				"greedy",
@@ -92,6 +69,7 @@ public class TrackastraOpt
 						.paramName( "Tracking mode" )
 						.addValue( "greedy" )
 						.fixedValue( "greedy" );
+
 		final ArrayParamSweepModel< String > useGPU = new ArrayParamSweepModel<>( new String[] {
 				"automatic",
 				"mps",
@@ -101,6 +79,7 @@ public class TrackastraOpt
 						.addValue( "automatic" )
 						.fixedValue( "automatic" );
 
+		final Map< String, AbstractParamSweepModel< ? > > models = new LinkedHashMap<>();
 		models.put( TrackastraCLI.KEY_CONDA_ENV, condaEnv );
 		models.put( TrackastraCLI.KEY_TRACKASTRA_MODEL, pretrainedModel );
 		models.put( TrackastraCLI.KEY_TRACKASTRA_PRETRAINED_OR_CUSTOM, pretrainedOrCustom );

--- a/src/main/java/fiji/plugin/trackmate/helper/ui/HelperLauncherPanel.java
+++ b/src/main/java/fiji/plugin/trackmate/helper/ui/HelperLauncherPanel.java
@@ -305,10 +305,10 @@ public class HelperLauncherPanel extends JPanel
 
 		btnBrowseGT.addActionListener( e -> {
 			final String dialogTitle = metricsChooserPanel.isCTCSelected()
-					? "Select a CTC ground-truth folder or TrackMate file."
+					? "Select a CTC ground-truth folder."
 					: "Select a SPT ground-truth XML file.";
 			final SelectionMode selectionMode = metricsChooserPanel.isCTCSelected()
-					? SelectionMode.FILES_AND_DIRECTORIES
+					? SelectionMode.DIRECTORIES_ONLY
 					: SelectionMode.FILES_ONLY;
 			final File file = FileChooser.chooseFile( this, tfGTPath.getText(), null, dialogTitle, DialogType.LOAD, selectionMode );
 			if ( file == null )

--- a/src/main/java/fiji/plugin/trackmate/helper/ui/ModuleParameterSweepPanel.java
+++ b/src/main/java/fiji/plugin/trackmate/helper/ui/ModuleParameterSweepPanel.java
@@ -8,12 +8,12 @@
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-3.0.html>.
@@ -40,6 +40,7 @@ import fiji.plugin.trackmate.helper.model.AbstractSweepModelBase.ModelListener;
 import fiji.plugin.trackmate.helper.model.parameter.AbstractParamSweepModel;
 import fiji.plugin.trackmate.helper.model.parameter.ArrayParamSweepModel;
 import fiji.plugin.trackmate.helper.model.parameter.BooleanParamSweepModel;
+import fiji.plugin.trackmate.helper.model.parameter.CondaEnvParamSweepModel;
 import fiji.plugin.trackmate.helper.model.parameter.InfoParamSweepModel;
 import fiji.plugin.trackmate.helper.model.parameter.NumberParamSweepModel;
 import fiji.plugin.trackmate.helper.model.parameter.StringRangeParamSweepModel;
@@ -52,7 +53,7 @@ import fiji.plugin.trackmate.helper.ui.components.StringRangeParamSweepPanel;
 /**
  * Panel that lets the user configure a parameter sweep over a TrackMate module
  * (detector or tracker).
- * 
+ *
  * @author Jean-Yves Tinevez
  */
 public class ModuleParameterSweepPanel extends JPanel
@@ -136,6 +137,8 @@ public class ModuleParameterSweepPanel extends JPanel
 			return new StringRangeParamSweepPanel( ( StringRangeParamSweepModel ) cm );
 		else if ( cm instanceof ArrayParamSweepModel< ? > )
 			return new ArrayRangeSweepPanel<>( ( ArrayParamSweepModel< ? > ) cm );
+		else if ( cm instanceof CondaEnvParamSweepModel )
+			return new ArrayRangeSweepPanel<>( ( CondaEnvParamSweepModel ) cm );
 		else if ( cm instanceof InfoParamSweepModel )
 			return new InfoPanel( ( InfoParamSweepModel ) cm );
 		else

--- a/src/main/java/fiji/plugin/trackmate/helper/ui/components/ArrayRangeSweepPanel.java
+++ b/src/main/java/fiji/plugin/trackmate/helper/ui/components/ArrayRangeSweepPanel.java
@@ -8,12 +8,12 @@
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-3.0.html>.
@@ -45,8 +45,8 @@ import javax.swing.border.EmptyBorder;
 
 import fiji.plugin.trackmate.gui.Fonts;
 import fiji.plugin.trackmate.gui.Icons;
+import fiji.plugin.trackmate.helper.model.parameter.AbstractArrayParamSweepModel.RangeType;
 import fiji.plugin.trackmate.helper.model.parameter.ArrayParamSweepModel;
-import fiji.plugin.trackmate.helper.model.parameter.ArrayParamSweepModel.RangeType;
 
 public class ArrayRangeSweepPanel< T > extends JPanel
 {

--- a/src/main/java/fiji/plugin/trackmate/helper/ui/components/ArrayRangeSweepPanel.java
+++ b/src/main/java/fiji/plugin/trackmate/helper/ui/components/ArrayRangeSweepPanel.java
@@ -45,7 +45,8 @@ import javax.swing.border.EmptyBorder;
 
 import fiji.plugin.trackmate.gui.Fonts;
 import fiji.plugin.trackmate.gui.Icons;
-import fiji.plugin.trackmate.helper.model.parameter.AbstractArrayParamSweepModel.RangeType;
+import fiji.plugin.trackmate.helper.model.parameter.AbstractArrayParamSweepModel;
+import fiji.plugin.trackmate.helper.model.parameter.AbstractArrayParamSweepModel.ArrayRangeType;
 import fiji.plugin.trackmate.helper.model.parameter.ArrayParamSweepModel;
 
 public class ArrayRangeSweepPanel< T > extends JPanel
@@ -69,11 +70,11 @@ public class ArrayRangeSweepPanel< T > extends JPanel
 
 	private final JLabel lblValuesList;
 
-	private final ArrayParamSweepModel< T > values;
+	private final AbstractArrayParamSweepModel< T, ? > values;
 
 	private final JButton btnRemove;
 
-	public ArrayRangeSweepPanel( final ArrayParamSweepModel< T > val )
+	public ArrayRangeSweepPanel( final AbstractArrayParamSweepModel< T, ? > val )
 	{
 		this.values = val;
 		setBorder( new EmptyBorder( 5, 5, 5, 5 ) );
@@ -90,7 +91,7 @@ public class ArrayRangeSweepPanel< T > extends JPanel
 		gbcLblParamName.gridy = 0;
 		add( lblParamName, gbcLblParamName );
 
-		rdbtnTestAll = new JRadioButton( "All values", val.getRangeType() == RangeType.TEST_ALL );
+		rdbtnTestAll = new JRadioButton( "All values", val.getRangeType() == ArrayRangeType.TEST_ALL );
 		final GridBagConstraints gbc_rdbtnTestAll = new GridBagConstraints();
 		gbc_rdbtnTestAll.anchor = GridBagConstraints.WEST;
 		gbc_rdbtnTestAll.gridwidth = 2;
@@ -99,7 +100,7 @@ public class ArrayRangeSweepPanel< T > extends JPanel
 		gbc_rdbtnTestAll.gridy = 1;
 		add( rdbtnTestAll, gbc_rdbtnTestAll );
 
-		rdbtnListValues = new JRadioButton( "Set of values", val.getRangeType() == RangeType.LIST );
+		rdbtnListValues = new JRadioButton( "Set of values", val.getRangeType() == ArrayRangeType.LIST );
 		final GridBagConstraints gbc_rdbtnManualRange = new GridBagConstraints();
 		gbc_rdbtnManualRange.anchor = GridBagConstraints.WEST;
 		gbc_rdbtnManualRange.gridwidth = 2;
@@ -144,7 +145,7 @@ public class ArrayRangeSweepPanel< T > extends JPanel
 		lblValuesList = new JLabel();
 		panelListValues.add( lblValuesList );
 
-		rdbtnFixed = new JRadioButton( "Fixed value", val.getRangeType() == RangeType.FIXED );
+		rdbtnFixed = new JRadioButton( "Fixed value", val.getRangeType() == ArrayRangeType.FIXED );
 		final GridBagConstraints gbcRdbtnFixed = new GridBagConstraints();
 		gbcRdbtnFixed.anchor = GridBagConstraints.WEST;
 		gbcRdbtnFixed.insets = new Insets( 0, 0, 0, 5 );
@@ -216,13 +217,13 @@ public class ArrayRangeSweepPanel< T > extends JPanel
 	private void update()
 	{
 		// Update model.
-		RangeType type;
+		ArrayRangeType type;
 		if ( rdbtnListValues.isSelected() )
-			type = RangeType.LIST;
+			type = ArrayRangeType.LIST;
 		else if ( rdbtnFixed.isSelected() )
-			type = RangeType.FIXED;
+			type = ArrayRangeType.FIXED;
 		else
-			type = RangeType.TEST_ALL;
+			type = ArrayRangeType.TEST_ALL;
 		values.rangeType( type ).fixedValue( ( T ) cmbboxFixedValue.getSelectedItem() );
 
 		// Update UI.
@@ -271,11 +272,11 @@ public class ArrayRangeSweepPanel< T > extends JPanel
 
 	public static void main( final String[] args )
 	{
-		final ArrayParamSweepModel< RangeType > model = new ArrayParamSweepModel<>( RangeType.values() )
+		final ArrayParamSweepModel< ArrayRangeType > model = new ArrayParamSweepModel<>( ArrayRangeType.values() )
 				.paramName( "Test enum" )
-				.rangeType( RangeType.LIST )
-				.addValue( RangeType.FIXED )
-				.addValue( RangeType.TEST_ALL );
+				.rangeType( ArrayRangeType.LIST )
+				.addValue( ArrayRangeType.FIXED )
+				.addValue( ArrayRangeType.TEST_ALL );
 
 		final JFrame frame = new JFrame();
 		frame.getContentPane().add( new ArrayRangeSweepPanel<>( model ) );

--- a/src/main/java/fiji/plugin/trackmate/helper/ui/components/BooleanRangeSweepPanel.java
+++ b/src/main/java/fiji/plugin/trackmate/helper/ui/components/BooleanRangeSweepPanel.java
@@ -39,7 +39,7 @@ import javax.swing.border.EmptyBorder;
 
 import fiji.plugin.trackmate.gui.Fonts;
 import fiji.plugin.trackmate.helper.model.parameter.BooleanParamSweepModel;
-import fiji.plugin.trackmate.helper.model.parameter.BooleanParamSweepModel.RangeType;
+import fiji.plugin.trackmate.helper.model.parameter.BooleanParamSweepModel.BooleanRangeType;
 
 public class BooleanRangeSweepPanel extends JPanel
 {
@@ -75,7 +75,7 @@ public class BooleanRangeSweepPanel extends JPanel
 		gbcLblParamName.gridy = 0;
 		add( lblParamName, gbcLblParamName );
 
-		rdbtnTestAll = new JRadioButton( "Test true and false", values.getRangeType() == RangeType.TEST_ALL );
+		rdbtnTestAll = new JRadioButton( "Test true and false", values.getRangeType() == BooleanRangeType.TEST_ALL );
 		final GridBagConstraints gbc_rdbtnTestAll = new GridBagConstraints();
 		gbc_rdbtnTestAll.gridwidth = 3;
 		gbc_rdbtnTestAll.anchor = GridBagConstraints.WEST;
@@ -84,7 +84,7 @@ public class BooleanRangeSweepPanel extends JPanel
 		gbc_rdbtnTestAll.gridy = 1;
 		add( rdbtnTestAll, gbc_rdbtnTestAll );
 
-		rdbtnFixed = new JRadioButton( "Fixed value", values.getRangeType() == RangeType.FIXED );
+		rdbtnFixed = new JRadioButton( "Fixed value", values.getRangeType() == BooleanRangeType.FIXED );
 		final GridBagConstraints gbcRdbtnFixed = new GridBagConstraints();
 		gbcRdbtnFixed.anchor = GridBagConstraints.WEST;
 		gbcRdbtnFixed.insets = new Insets( 0, 0, 0, 5 );
@@ -141,7 +141,7 @@ public class BooleanRangeSweepPanel extends JPanel
 	private void update()
 	{
 		// Update model.
-		final RangeType type = ( rdbtnTestAll.isSelected() ) ? RangeType.TEST_ALL : RangeType.FIXED;
+		final BooleanRangeType type = ( rdbtnTestAll.isSelected() ) ? BooleanRangeType.TEST_ALL : BooleanRangeType.FIXED;
 		values.rangeType( type )
 				.fixedValue( rdbtnTrue.isSelected() );
 


### PR DESCRIPTION
This PR introduces the following 'quality of life' improvements for the user:

1. 
When a user launch the plugin in a location that contains a `helperrunnersettings.json` file, it deserializes it to present the user with last used parameter sweep configuration. 

But sometimes users may have serialized that the module was not available or properly configured at the time of serialization. For instance if you did not install TrackMate-Trackastra, the fact that it is missing will be serialized. And it will be deserialized, even if the TrackMate-Trackastra module has become available. 

Now when deserializing, we detect whether we serialized such a case, and if yes, we try to re-discover the module.

2.
We now have a special parameter for conda environments. The list of conda environments available is still serialized, but it is ignored when deserializing, and replaced with the list of actual conda environments present at runtime.

3.
The serialization logic is still complicated. I could not find a good way to simplify it keeping everything we want for the user.
I tried to at least clarify it a bit, and use non-conflicting class names.
